### PR TITLE
feat: expose strategy metadata in API

### DIFF
--- a/docs/internals/server_api.md
+++ b/docs/internals/server_api.md
@@ -36,7 +36,7 @@ NOTE: The API does not have dedicated versioning, instead it uses the version of
 
 ### GET /api/strategies
 
-Get all strategies known to this Gekko. The value of the `params` key is a TOML string.
+Get all strategies known to this Gekko. The value of the `params` key is a TOML string. Each strategy may also include a `description` and `category` to help with discovery in the UI.
 
 **response**
 
@@ -44,20 +44,16 @@ Get all strategies known to this Gekko. The value of the `params` key is a TOML 
 [
   {
     "name": "DEBUG_single-advice",
-    "params": ""
-  },
-  {
-    "name": "DEBUG_toggle-advice",
-    "params": ""
-  },
-  {
-    "name": "DEMA",
-    "params": "weight = 21\n\n[thresholds]\ndown = -0.025\nup = 0.025\n"
+    "params": "",
+    "description": "",
+    "category": ""
   },
   {
     "name": "MACD",
-    "params": "short = 10\nlong = 21\nsignal = 9\n\n[thresholds]\ndown = -0.025\nup = 0.025\npersistence = 1"
-  },
+    "params": "short = 10\nlong = 21\nsignal = 9\n\n[thresholds]\ndown = -0.025\nup = 0.025\npersistence = 1",
+    "description": "Moving Average Convergence Divergence trend-following strategy.",
+    "category": "trend"
+  }
   // etc.
 ]
 ```

--- a/strategies/metadata.js
+++ b/strategies/metadata.js
@@ -1,0 +1,26 @@
+module.exports = {
+  CCI: {
+    description: 'Commodity Channel Index strategy identifying cyclical trends.',
+    category: 'momentum'
+  },
+  MACD: {
+    description: 'Moving Average Convergence Divergence trend-following strategy.',
+    category: 'trend'
+  },
+  PPO: {
+    description: 'Percentage Price Oscillator momentum strategy.',
+    category: 'momentum'
+  },
+  RSI: {
+    description: 'Relative Strength Index momentum strategy.',
+    category: 'momentum'
+  },
+  TMA: {
+    description: 'Triple Moving Average trend strategy.',
+    category: 'trend'
+  },
+  TSI: {
+    description: 'True Strength Index momentum oscillator strategy.',
+    category: 'momentum'
+  }
+};

--- a/web/routes/strategies.js
+++ b/web/routes/strategies.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const fs = require('co-fs');
+const meta = require('../../strategies/metadata');
 
 const gekkoRoot = __dirname + '/../../';
 
@@ -21,6 +22,15 @@ module.exports = function *() {
       strat.params = yield fs.readFile(stratConfigPath + '/' + strat.name + '.toml', 'utf8')
     else
       strat.params = '';
+
+    const info = meta[strat.name];
+    if(info) {
+      strat.description = info.description;
+      strat.category = info.category;
+    } else {
+      strat.description = '';
+      strat.category = '';
+    }
   }
 
   this.body = strats;


### PR DESCRIPTION
## Summary
- add human-readable descriptions and categories for core strategies
- extend `/api/strategies` route to return strategy metadata
- document new `description` and `category` fields in server API docs

## Testing
- `npm test`
